### PR TITLE
skip parsing event if no location field provided

### DIFF
--- a/utilities/sourceEvents.py
+++ b/utilities/sourceEvents.py
@@ -103,8 +103,8 @@ def parse(content, gmaps):
     xmltoMongoDB = []
 
     for pe in XML2JSON:
-        #don't add events without location
-        if 'location' not in pe:
+        #don't add events a) without location b) with empty location
+        if 'location' not in pe or if len(pe['location']) == 0:
             continue
 
         entry = dict()


### PR DESCRIPTION
[TASK] #200  Do not push events that does not contain location in WebTools

in parse function, checks if location tag present before proceeding