### PR TITLE
Delete from building block followed by local db

### DIFF
--- a/utilities/user_utilities.py
+++ b/utilities/user_utilities.py
@@ -103,8 +103,6 @@ def delete_user_event_in_building_block(objectId_list):
     fail_count = 0
     for _id in objectId_list:
         event = find_one(current_app.config['EVENT_COLLECTION'], condition=_id)
-        # EVENT_BUILDING_BLOCK_URL is specified as http://localhost:9000/events
-        # shouldn't it be http://localhost:9000/eventsmanager_events?
         url = current_app.config['EVENT_BUILDING_BLOCK_URL'] + '/' + str(event.get('platformEventId'))
         result = requests.delete(url, headers=headers)
         if result.status_code != 202:
@@ -127,7 +125,7 @@ def delete_user_event(eventId):
     # Since we're only dealing with deleting a singular item at a time
     # if delete_count < 1, the item wasn't successfully deleted off of the events building block
     if delete_count < 1:
-        print("Event deletion failed")
+        print("Event {} deletion failed".format(id))
         return
     else:
         delete_event_local = delete_events_in_list(current_app.config['EVENT_COLLECTION'], successfull_delete_list)


### PR DESCRIPTION
Implemented delete in similar way to source events. Upon triggering deletion we try to delete it off of the events building block, if that's not possible the event isn't deleted locally either (to maintain uniformity). On successful deletion off of the events building block item is deleted locally as well.   