### PR TITLE
added space between buttons on popup windows

### DIFF
--- a/templates/events/confirmation.html
+++ b/templates/events/confirmation.html
@@ -34,8 +34,8 @@
         {% endif %}
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary"
+        <button type="button" class="btn btn-secondary mr-2" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary ml-1"
         {% if usage == "approve" or usage == "approveEvent" %}
         id="approvebutton"
         {% elif usage == "disapprove" or usage == "disapproveEvent" %}

--- a/templates/events/event.html
+++ b/templates/events/event.html
@@ -35,8 +35,8 @@
         You are about to delete the following event <b>{{post.title}}</b>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" id="deletion-modal-btn-yes">Confirm</button>
+        <button type="button" class="btn btn-secondary mr-2" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary ml-1" id="deletion-modal-btn-yes">Confirm</button>
       </div>
     </div>
   </div>

--- a/templates/events/notification.html
+++ b/templates/events/notification.html
@@ -54,8 +54,8 @@
                     <label for="confirmNotification" class="col-12 col-form-label"><center>Do you want to send this notification?</center></label>
                   </div>
                    <div class="col text-center">
-                    <button type="button" class="btn btn-secondary" id="notification-modal-btn-no">No</button>
-                    <button type="submit" class="btn btn-primary" id="notification-modal-btn-yes">Yes</button>
+                    <button type="button" class="btn btn-secondary mr-2" id="notification-modal-btn-no">No</button>
+                    <button type="submit" class="btn btn-primary ml-1" id="notification-modal-btn-yes">Yes</button>
                   </div>
                 </form>
               </div>


### PR DESCRIPTION
Added space between buttons on popup windows which will be shown when user clicks "delete" "publish" or "notification". 