### PR TITLE
Fix the problem in the edit page, allDay event without endDate would show datetime formate

### DIFF
--- a/templates/events/event-edit.html
+++ b/templates/events/event-edit.html
@@ -227,7 +227,11 @@
                 <h5> End Date</h5>
               </div>
               <div class="col-sm-4">
+                {% if post.allDay == True %}
+                <input class="form-control" type="date" id="endDate" name="endDate" max="9999-12-31"/>
+                {% else %}
                 <input class="form-control" type="datetime-local" id="endDate" name="endDate" max="9999-12-31T23:59:59"/>
+                {% endif %}
               </div>
             </div>
           {% endif %}


### PR DESCRIPTION
closes #434 
Previously:
![Screen Shot 2020-07-10 at 3 19 30 PM](https://user-images.githubusercontent.com/44145249/87199531-c3a37400-c2c0-11ea-8cf2-6b3abb998839.png)
the EndDate format would cause error.
Now fixed:
![Screen Shot 2020-07-10 at 3 21 14 PM](https://user-images.githubusercontent.com/44145249/87199871-01a09800-c2c1-11ea-9426-ccb3c28175f5.png)
