### PR TITLE
startDate / endDate constraints

### DIFF
--- a/templates/events/add-new-event.html
+++ b/templates/events/add-new-event.html
@@ -548,7 +548,6 @@
         } 
         date = yyyy+'-'+mm+'-'+dd;
         var dateTime = date+'T'+'00:00:00';
-        document.getElementById("startDate").setAttribute("min", dateTime);
         if ($startDate.val() != ""){
           document.getElementById("endDate").setAttribute("min", $startDate.val());
 
@@ -614,7 +613,6 @@
     } 
     date = yyyy+'-'+mm+'-'+dd;
     var dateTime = date+'T'+'00:00:00';
-    document.getElementById("startDate").setAttribute("min", dateTime);
     document.getElementById("endDate").setAttribute("min", dateTime);
     
    </script>

--- a/templates/events/add-new-event.html
+++ b/templates/events/add-new-event.html
@@ -503,13 +503,46 @@
       if (this.checked) {
         $("#startDate").attr("type", "date");
         $("#endDate").attr("type", "date");
+        var today = new Date();
+        var dd = today.getDate();
+        var mm = today.getMonth()+1; 
+        var yyyy = today.getFullYear();
+        if(dd<10){
+          dd='0'+dd
+        } 
+        if(mm<10){
+          mm='0'+mm
+        } 
+        date = yyyy+'-'+mm+'-'+dd;
+        document.getElementById("startDate").setAttribute("min", date);
+        document.getElementById("endDate").setAttribute("min", date);
       }
       else {
         $("#startDate").attr("type", "datetime-local");
         $("#endDate").attr("type", "datetime-local");
+        var today = new Date();
+        var dd = today.getDate();
+        var mm = today.getMonth()+1; 
+        var yyyy = today.getFullYear();
+        if(dd<10){
+          dd='0'+dd
+        } 
+        if(mm<10){
+          mm='0'+mm
+        } 
+        date = yyyy+'-'+mm+'-'+dd;
+        var dateTime = date+'T'+'00:00:00';
+        document.getElementById("startDate").setAttribute("min", dateTime);
+        document.getElementById("endDate").setAttribute("min", dateTime);
       }
 
     });
+
+    // Handle endDate constraint based on the choice of startDate
+    $('#startDate').change(function(){
+      var start = $('#startDate').val()
+      document.getElementById("endDate").setAttribute("min", start)
+    })
 
     // Handle image upload and preview
     $('input[type="file"]').change(function(input){
@@ -543,6 +576,23 @@
       $("#file").val(null);
       $('#preview-image').attr('src', '');
     });
+
+    // set the min value of startDate and endDate to be current time
+    var today = new Date();
+    var dd = today.getDate();
+    var mm = today.getMonth()+1; 
+    var yyyy = today.getFullYear();
+    if(dd<10){
+      dd='0'+dd
+    } 
+    if(mm<10){
+      mm='0'+mm
+    } 
+    date = yyyy+'-'+mm+'-'+dd;
+    var dateTime = date+'T'+'00:00:00';
+    document.getElementById("startDate").setAttribute("min", dateTime);
+    document.getElementById("endDate").setAttribute("min", dateTime);
+    
 
    </script>
 {% endblock %}

--- a/templates/events/add-new-event.html
+++ b/templates/events/add-new-event.html
@@ -499,10 +499,16 @@
 
    // Handle all-day event
     $("#allDay").change(function () {
+      let $startDate = $("#startDate");
+      let $endDate = $("#endDate");
+
+      let startDate = moment($startDate.val());
+      let endDate = moment($endDate.val());
 
       if (this.checked) {
-        $("#startDate").attr("type", "date");
-        $("#endDate").attr("type", "date");
+        $endDate.attr("type", "date");
+        $startDate.attr("type", "date");
+        console.log($startDate.val())
         var today = new Date();
         var dd = today.getDate();
         var mm = today.getMonth()+1; 
@@ -515,11 +521,21 @@
         } 
         date = yyyy+'-'+mm+'-'+dd;
         document.getElementById("startDate").setAttribute("min", date);
-        document.getElementById("endDate").setAttribute("min", date);
+        $startDate.val(startDate.format("YYYY-MM-DD"));
+        $endDate.val(endDate.format("YYYY-MM-DD"));
+        if ($startDate.val() != ""){
+          document.getElementById("endDate").setAttribute("min", $startDate.val());
+
+        } else {
+          document.getElementById("endDate").setAttribute("min", date);
+        }
       }
       else {
-        $("#startDate").attr("type", "datetime-local");
-        $("#endDate").attr("type", "datetime-local");
+        $startDate.attr("type", "datetime-local");
+        $endDate.attr("type", "datetime-local");
+
+        $startDate.val(startDate.format("YYYY-MM-DDTHH:mm"));
+        $endDate.val(endDate.hour(23).minute(59).format("YYYY-MM-DDTHH:mm"));
         var today = new Date();
         var dd = today.getDate();
         var mm = today.getMonth()+1; 
@@ -533,9 +549,13 @@
         date = yyyy+'-'+mm+'-'+dd;
         var dateTime = date+'T'+'00:00:00';
         document.getElementById("startDate").setAttribute("min", dateTime);
-        document.getElementById("endDate").setAttribute("min", dateTime);
-      }
+        if ($startDate.val() != ""){
+          document.getElementById("endDate").setAttribute("min", $startDate.val());
 
+        } else {
+          document.getElementById("endDate").setAttribute("min", date);
+        }
+      }
     });
 
     // Handle endDate constraint based on the choice of startDate
@@ -593,7 +613,6 @@
     document.getElementById("startDate").setAttribute("min", dateTime);
     document.getElementById("endDate").setAttribute("min", dateTime);
     
-
    </script>
 {% endblock %}
 

--- a/templates/events/add-new-event.html
+++ b/templates/events/add-new-event.html
@@ -562,6 +562,10 @@
     $('#startDate').change(function(){
       var start = $('#startDate').val()
       document.getElementById("endDate").setAttribute("min", start)
+      var end = $('#endDate').val()
+      if (end < start){
+        $('#endDate').val(null)
+      }
     })
 
     // Handle image upload and preview
@@ -597,7 +601,7 @@
       $('#preview-image').attr('src', '');
     });
 
-    // set the min value of startDate and endDate to be current time
+    // set the min value of startDate and endDate to be current time as the default behavior
     var today = new Date();
     var dd = today.getDate();
     var mm = today.getMonth()+1; 

--- a/templates/events/event-edit.html
+++ b/templates/events/event-edit.html
@@ -935,35 +935,74 @@
    }
 
    // Handle all-day event
-    $("#allDay").change(function () {
+   $("#allDay").change(function () {
+      let $startDate = $("#startDate");
+      let $endDate = $("#endDate");
 
-        let $startDate = $("#startDate");
-        let $endDate = $("#endDate");
+      let startDate = moment($startDate.val());
+      let endDate = moment($endDate.val());
 
-        let startDate = moment($startDate.val());
-        let endDate = moment($endDate.val());
+      if (this.checked) {
+        $endDate.attr("type", "date");
+        $startDate.attr("type", "date");
+        console.log($startDate.val())
+        var today = new Date();
+        var dd = today.getDate();
+        var mm = today.getMonth()+1; 
+        var yyyy = today.getFullYear();
+        if(dd<10){
+          dd='0'+dd
+        } 
+        if(mm<10){
+          mm='0'+mm
+        } 
+        date = yyyy+'-'+mm+'-'+dd;
+        document.getElementById("startDate").setAttribute("min", date);
+        $startDate.val(startDate.format("YYYY-MM-DD"));
+        $endDate.val(endDate.format("YYYY-MM-DD"));
+        if ($startDate.val() != ""){
+          document.getElementById("endDate").setAttribute("min", $startDate.val());
 
-        if (this.checked) {
-          $endDate.attr("type", "date");
-          $startDate.attr("type", "date");
-
-          $startDate.val(startDate.format("YYYY-MM-DD"));
-          $endDate.val(endDate.format("YYYY-MM-DD"));
+        } else {
+          document.getElementById("endDate").setAttribute("min", date);
+        }
       }
       else {
-          $startDate.attr("type", "datetime-local");
-          $endDate.attr("type", "datetime-local");
+        $startDate.attr("type", "datetime-local");
+        $endDate.attr("type", "datetime-local");
 
-          $startDate.val(startDate.format("YYYY-MM-DDTHH:mm"));
-          $endDate.val(endDate.hour(23).minute(59).format("YYYY-MM-DDTHH:mm"));
+        $startDate.val(startDate.format("YYYY-MM-DDTHH:mm"));
+        $endDate.val(endDate.hour(23).minute(59).format("YYYY-MM-DDTHH:mm"));
+        var today = new Date();
+        var dd = today.getDate();
+        var mm = today.getMonth()+1; 
+        var yyyy = today.getFullYear();
+        if(dd<10){
+          dd='0'+dd
+        } 
+        if(mm<10){
+          mm='0'+mm
+        } 
+        date = yyyy+'-'+mm+'-'+dd;
+        var dateTime = date+'T'+'00:00:00';
+        document.getElementById("startDate").setAttribute("min", dateTime);
+        if ($startDate.val() != ""){
+          document.getElementById("endDate").setAttribute("min", $startDate.val());
+
+        } else {
+          document.getElementById("endDate").setAttribute("min", date);
+        }
       }
-
     });
 
     // Handle endDate constraint based on the choice of startDate
     $('#startDate').change(function(){
       var start = $('#startDate').val()
       document.getElementById("endDate").setAttribute("min", start)
+      var end = $('#endDate').val()
+      if (end < start){
+        $('#endDate').val(null)
+      }
     })
 
     // Handle image upload and preview
@@ -1002,7 +1041,7 @@
       document.getElementById("delete-image").value = 1
     });
 
-    // set the min value of startDate to be current time
+    // set the min value of startDate to be current time as the default behavior
     var today = new Date();
     var dd = today.getDate();
     var mm = today.getMonth()+1; 

--- a/templates/events/event-edit.html
+++ b/templates/events/event-edit.html
@@ -985,7 +985,6 @@
         } 
         date = yyyy+'-'+mm+'-'+dd;
         var dateTime = date+'T'+'00:00:00';
-        document.getElementById("startDate").setAttribute("min", dateTime);
         if ($startDate.val() != ""){
           document.getElementById("endDate").setAttribute("min", $startDate.val());
 
@@ -1054,7 +1053,6 @@
     } 
     date = yyyy+'-'+mm+'-'+dd;
     var dateTime = date+'T'+'00:00:00';
-    document.getElementById("startDate").setAttribute("min", dateTime);
 
     // set the min value of endDate to be startDate
     var start = $('#startDate').val()

--- a/templates/events/event-edit.html
+++ b/templates/events/event-edit.html
@@ -960,6 +960,12 @@
 
     });
 
+    // Handle endDate constraint based on the choice of startDate
+    $('#startDate').change(function(){
+      var start = $('#startDate').val()
+      document.getElementById("endDate").setAttribute("min", start)
+    })
+
     // Handle image upload and preview
     $('input[type="file"]').change(function(input){
         //console.log("detect image change");
@@ -995,6 +1001,25 @@
       $("#form").off('change input');
       document.getElementById("delete-image").value = 1
     });
+
+    // set the min value of startDate to be current time
+    var today = new Date();
+    var dd = today.getDate();
+    var mm = today.getMonth()+1; 
+    var yyyy = today.getFullYear();
+    if(dd<10){
+      dd='0'+dd
+    } 
+    if(mm<10){
+      mm='0'+mm
+    } 
+    date = yyyy+'-'+mm+'-'+dd;
+    var dateTime = date+'T'+'00:00:00';
+    document.getElementById("startDate").setAttribute("min", dateTime);
+
+    // set the min value of endDate to be startDate
+    var start = $('#startDate').val()
+    document.getElementById("endDate").setAttribute("min", start);
 
    </script>
    <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ apiKey }}&callback=initMap"></script>


### PR DESCRIPTION
**- In the add new event page:**
Both startDate and endDate's min values are the current time. (So user can only add events for future)
Once startDate has been chosen: endDate's min value is startDate. (So the endDate can only be later than startDate)
If the user changes startDate resulting endDate is before startDate, then endDate will reset to null.
Conversion from allDay to date-time works fine.

**- In the edit event page:**
The min value of startDate is the current time. (User can only modify the startDate to be today or later than today)
The min value of endDate is the startDate. (endDate can only be later than startDate)
If the user changes startDate resulting endDate is before startDate, then endDate will reset to null.
Conversion from allDay to date-time works fine.

The above constraints apply to both allDay events and regular events.

closes #470 