### PR TITLE
Add multistage build to cut Docker image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix subevent name updates [#505](https://github.com/rokwire/events-manager/issues/505)
 
+### Changed
+- Reduces container image size to 498 MB from 1.27 GB using a multistage
+  Dockerfile [#507](https://github.com/rokwire/events-manager/pull/507)
+
+### Security
+- The container runs gunicorn as user nobody instead of as root
+  [#507](https://github.com/rokwire/events-manager/pull/507)
+- Eliminates all unnecessary development tools used to build container
+  [#507](https://github.com/rokwire/events-manager/pull/507)
+
 ## [2.1.1] - 2020-08-05
 ### Fixed
 - Fix user event datetime conversion [#492](https://github.com/rokwire/events-manager/issues/492)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,39 @@
-FROM python:3.7.4
+FROM python:3.7.4-slim-buster as base
 
 LABEL maintainer="Bing Zhang <bing@illinois.edu>"
 LABEL contributor="Siheng Pan <span14@illinois.edu>, Han Jiang <hanj2@illinois.edu>, Phoebe Tang <panqiut2@illinois.edu>, Bing Zhang <bing@illinois.edu>"
 
-RUN apt-get update && apt-get install -y libldap2-dev libsasl2-dev libssl-dev
+# Libraries needed to run python-ldap and GitPython
+RUN apt-get update && apt-get install -y \
+      libldap-2.4-2 \
+      libsasl2-2 \
+      git \
+ && rm -rf /var/lib/apt/lists/*
+
+FROM base as requirements
+
+# Packages needed to build python-ldap
+RUN apt-get update && apt-get install -y \
+      gcc \
+      libldap2-dev \
+      libsasl2-dev \
+      libssl-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Build and install requirements
+COPY requirements.txt /app/events-manager/
+RUN pip install --user -r /app/events-manager/requirements.txt
+RUN chmod -R oug+r /root/.local
+RUN find /root/.local -type d -exec chmod oug+x {} +
+
+FROM base
 
 WORKDIR /app
 COPY . /app/events-manager/
-RUN pip install -r /app/events-manager/requirements.txt
+RUN python -m compileall .
+
+COPY --from=requirements /root/.local /usr/local
+
+USER nobody
 
 CMD ["gunicorn", "events-manager:create_app()", "--config", "/app/events-manager/gunicorn.config.py", "--timeout", "7200"]


### PR DESCRIPTION
- Reduces image size to 498 MB from 1.27 GB
- Improves security
  - Container now runs as user nobody
  - Eliminates all unnecessary development tools used to build
  Python packages