### PR TITLE
620 fix issue with manual calendar events download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Do pagination downloading on campus events from webtool endpoint.[#607](https://github.com/rokwire/events-manager/issues/607).
 
+### Fixed
+- Issue with download scheduler (when using manual calendar events download) blocking the web app and resulting in internal server error. [#620](https://github.com/rokwire/events-manager/issues/620).
+
 ## [2.3.1] - 2021-03-22
 ### Security
 - Bump pillow from 8.0.0 to 8.1.1.(https://github.com/rokwire/events-manager/pull/610)

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN chmod -R 755 /app/images /app/temp
 
 USER nobody
 
-CMD ["gunicorn", "events-manager:create_app()", "--config", "/app/events-manager/gunicorn.config.py", "--timeout", "7200"]
+CMD ["gunicorn", "events-manager:create_app()", "--config", "/app/events-manager/gunicorn.config.py", "--timeout", "7200", "--preload"]

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -16,4 +16,4 @@
 
 bind = '0.0.0.0:5000'
 
-workers = 1
+workers = 2


### PR DESCRIPTION
## Description
_Please provide a summary of the pull request and the issue it fixes. Please add necessary details, context, dependencies, explanation of when review is needed (see next section), etc._

This PR fixes the issue of the manual download of calendar data resulting in an internal server error. Most likely, this was caused due to the web app blocking other requests (like health checks) when manual download is in progress. Because of this, AWS restarts the Events Manager instance unknowing that the instance is just busy downloading data. 

This PR also addresses the issue that users could not use Events Manager when a download was in progress, due to the web app blocking on the download process.

This is fixed by using the --preload option of gunicorn, thereby loading the app code before the workers are created. The APScheduler thus gets bound to the initial app code that was loaded, resulting in only a s single scheduler even though the number of workers is increased.

**Fixes #620**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)

