### PR TITLE
fix importlib_resources legacy incompatible in timezonefinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Category name mappings. [#1092](https://github.com/rokwire/events-manager/issues/1092)
+- Fix cannot import name 'open_binary' from 'importlib_resources'. [#1097](https://github.com/rokwire/events-manager/issues/1097)
 
 ## [3.5.0] - 2023-04-02
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.8-slim-buster as base
+FROM python:3.9-slim-buster as base
 
 LABEL maintainer="Bing Zhang <bing@illinois.edu>"
-LABEL contributor="Siheng Pan <span14@illinois.edu>, Han Jiang <hanj2@illinois.edu>, Phoebe Tang <panqiut2@illinois.edu>, Bing Zhang <bing@illinois.edu>"
+LABEL contributor="Puthanveetil Satheesan, Sandeep <sandeeps@illinois.edu>, Mathew, Minu <minum@illinois.edu>, Bing Zhang <bing@illinois.edu>"
 
 # Libraries needed to run python-ldap and GitPython
 RUN apt-get update && apt-get install -y \

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ gunicorn==19.9.0
 APScheduler>=3.3.0,<4
 python-ldap==3.4.0
 pytz==2019.2
-timezonefinder==4.1.0
+timezonefinder==6.2.0
 pyfcm==1.4.7
 GitPython==3.1.32
 python-dotenv==0.20.0


### PR DESCRIPTION
I tested that. It needs to increase the timezone finder version to resolve the legacy incompatible issue in importlib_resources package.

Meanwhile, I increase the python from 3.8 to 3.9.

Update the contributor list.